### PR TITLE
Add handling for when exif data couldn't be read

### DIFF
--- a/src/ImageOrientationFixer/OrientationReader/ExifReader.php
+++ b/src/ImageOrientationFixer/OrientationReader/ExifReader.php
@@ -21,6 +21,10 @@ class ExifReader implements ReaderInterface
         }
 
         $exif = exif_read_data($image->getPath());
+        if ($exif === false) {
+            throw new ImageOrientationException('Unknown orientation - exif data couldn\'t be parsed');
+        }
+
         $orientation = null;
 
         if(!empty($exif['Orientation'])) {


### PR DESCRIPTION
When exif data cannot be read, the `exif_read_data` function will return false. 

This should handle that.