### PR TITLE
fixed an 'Undefined index: Orientation' notice

### DIFF
--- a/src/ImageOrientationFixer/OrientationReader/ExifReader.php
+++ b/src/ImageOrientationFixer/OrientationReader/ExifReader.php
@@ -16,30 +16,32 @@ class ExifReader implements ReaderInterface
      */
     public function getOrientation(Image $image)
     {
-        if(!function_exists('exif_read_data')) {
+        if (!function_exists('exif_read_data')) {
             throw new ImageOrientationException(sprintf('EXIF module not loaded!'));
         }
 
         $exif = exif_read_data($image->getPath());
         if ($exif === false) {
-            throw new ImageOrientationException('Unknown orientation - exif data couldn\'t be parsed');
+            throw new ImageOrientationException('Unknown orientation - EXIF data couldn\'t be parsed');
         }
 
-        $orientation = null;
-
-        if(!empty($exif['Orientation'])) {
-            switch($exif['Orientation']) {
-                case self::ORIENTATION_0:
-                case self::ORIENTATION_270:
-                case self::ORIENTATION_180:
-                case self::ORIENTATION_90:
-                    $orientation = (int) $exif['Orientation'];
-                    break;
-
-            }
+        if (empty($exif['Orientation'])) {
+            throw new ImageOrientationException('No EXIF Orientation data available.');
         }
 
-        if(null === $orientation) {
+        switch ($exif['Orientation']) {
+            case self::ORIENTATION_0:
+            case self::ORIENTATION_270:
+            case self::ORIENTATION_180:
+            case self::ORIENTATION_90:
+                $orientation = (int) $exif['Orientation'];
+                break;
+            default:
+                $orientation = null;
+                break;
+        }
+
+        if (null === $orientation) {
             throw new ImageOrientationException(sprintf('Unknown orientation: %s!', $exif['Orientation']));
         }
 


### PR DESCRIPTION
This PR fixes a notice in the EXIFReader class when there is no `Orientation` data available in the exif data.